### PR TITLE
Fixed BSMLParser exception on exit

### DIFF
--- a/ModList/UI/ModListButtonManager.cs
+++ b/ModList/UI/ModListButtonManager.cs
@@ -41,7 +41,7 @@ namespace IPA.ModList.BeatSaber.UI
                 return;
             }
 
-            if (MenuButtons.IsSingletonAvailable)
+            if (BSMLParser.IsSingletonAvailable && MenuButtons.IsSingletonAvailable)
             {
                 MenuButtons.instance.UnregisterButton(modListButton);
             }


### PR DESCRIPTION
Fixes the exception below:
```
[WARNING @ 15:04:45 | UnityEngine] [Singleton] Instance 'BeatSaberMarkupLanguage.BSMLParser' already destroyed on application quit. Won't create again - returning null.
[CRITICAL @ 15:04:45 | UnityEngine] NullReferenceException: Object reference not set to an instance of an object
[CRITICAL @ 15:04:45 | UnityEngine] BeatSaberMarkupLanguage.ViewControllers.BSMLAutomaticViewController.ParseWithFallback () (at <b4eb087cdb83467e81730896a6cd01de>:0)
[CRITICAL @ 15:04:45 | UnityEngine] BeatSaberMarkupLanguage.ViewControllers.BSMLAutomaticViewController.DidActivate (System.Boolean firstActivation, System.Boolean addedToHierarchy, System.Boolean screenSystemEnabling) (at <b4eb087cdb83467e81730896a6cd01de>:0)
[CRITICAL @ 15:04:45 | UnityEngine] BeatSaberMarkupLanguage.MenuButtons.MenuButtonsViewController.RefreshView () (at <b4eb087cdb83467e81730896a6cd01de>:0)
[CRITICAL @ 15:04:45 | UnityEngine] BeatSaberMarkupLanguage.MenuButtons.MenuButtons.Refresh () (at <b4eb087cdb83467e81730896a6cd01de>:0)
[CRITICAL @ 15:04:45 | UnityEngine] BeatSaberMarkupLanguage.MenuButtons.MenuButtons.UnregisterButton (BeatSaberMarkupLanguage.MenuButtons.MenuButton menuButton) (at <b4eb087cdb83467e81730896a6cd01de>:0)
[CRITICAL @ 15:04:45 | UnityEngine] IPA.ModList.BeatSaber.UI.ModListButtonManager.Dispose () (at <bef3ac00153c4cc3b42bc3a90ff33bf6>:0)
[CRITICAL @ 15:04:45 | UnityEngine] Zenject.DisposableManager.Dispose () (at <b2cc02012594432582d34a1cdfb29cd9>:0)
[CRITICAL @ 15:04:45 | UnityEngine] Rethrow as ZenjectException: Error occurred while disposing IDisposable with type 'ModListButtonManager'
[CRITICAL @ 15:04:45 | UnityEngine] Zenject.DisposableManager.Dispose () (at <b2cc02012594432582d34a1cdfb29cd9>:0)
[CRITICAL @ 15:04:45 | UnityEngine] Zenject.MonoKernel.OnDestroy () (at <b2cc02012594432582d34a1cdfb29cd9>:0)
```

_Persistent singletons really do be cringe._